### PR TITLE
Added default route from 'index' to 'posts' to match screencast

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -14,6 +14,12 @@ App.Router.map(function() {
   });
 });
 
+App.IndexRoute = Ember.Route.extend({
+  redirect: function () {
+    this.transitionTo('posts');
+  }
+});
+
 App.PostsRoute = Ember.Route.extend({
   model: function() {
     return App.Post.find();


### PR DESCRIPTION
I wanted to do the default route as explained in the video and didn't find it in this code, so I figured I'd add it so no one would need to transcribe it from the video in the future :)
