### PR TITLE
Adjust new Date fixture syntax [Firefox Bug]

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4,14 +4,14 @@ var posts = [{
   id: '1',
   title: "Rails is Omakase",
   author: { name: "d2h" },
-  date: new Date('12-27-2012'),
+  date: new Date('Dec 27, 2012'),
   excerpt: "There are lots of à la carte software environments in this world. Places where in order to eat, you must first carefully look over the menu of options to order exactly what you want.",
   body: "I want this for my ORM, I want that for my template language, and let's finish it off with this routing library. Of course, you're going to have to know what you want, and you'll rarely have your horizon expanded if you always order the same thing, but there it is. It's a very popular way of consuming software.\n\nRails is not that. Rails is omakase."
 }, {
   id: '2',
   title: "The Parley Letter",
   author: { name: "d2h" },
-  date: new Date('12-24-2012'),
+  date: new Date('Dec 24, 2012'),
   excerpt: "My [appearance on the Ruby Rogues podcast](http://rubyrogues.com/056-rr-david-heinemeier-hansson/) recently came up for discussion again on the private Parley mailing list.",
   body: "A long list of topics were raised and I took a time to ramble at large about all of them at once. Apologies for not taking the time to be more succinct, but at least each topic has a header so you can skip stuff you don't care about.\n\n### Maintainability\n\nIt's simply not true to say that I don't care about maintainability. I still work on the oldest Rails app in the world."  
 }];


### PR DESCRIPTION
I noticed while following along with the screencast that the dates were not working properly in Firefox. Cloning the repo of the screencast, it seems to not be working as well in Firefox. The string date passed into `new Date()` must be compatible with `Date.parse()`, [according to the MDN JS docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).

This PR adjusts the way that the date is created with a format that is compatible with Firefox (and still works in Chrome).
